### PR TITLE
Automatically add current year to the footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,9 +116,11 @@
             </g>
             </svg></a>
         
-        &copy; 2022 Alekzandriia. All Rights Reserved.
+        <p>&copy; <span id="year"></span> Alekzandriia. All Rights Reserved.</p>
     </footer>
-
+      <script>
+  document.getElementById("year").innerHTML = new Date().getFullYear();
+  </script>
     <script src="script.js"></script>
 </body>
 


### PR DESCRIPTION
This code makes it so that the current year is automatically fetched by JavaScript and the website maintainer does not need to manually update and hard code it every year.